### PR TITLE
Allow slides to change with only button presses

### DIFF
--- a/README.md
+++ b/README.md
@@ -237,6 +237,9 @@ class MySplashScreenState extends State<MySplashScreen> {
 
       // Show or hide status bar
       shouldHideStatusBar: true,
+
+      // Change slides only with buttons
+      isScrollable: false,
     );
   }
 }
@@ -317,5 +320,7 @@ class MySplashScreenState extends State<MySplashScreen> {
 | locale                | `String`    | 'en'                  | 'en' or 'ar' To set the default locale and adjust the direction of widgets       |
 | <b>Status bar</b>     |             |                       |                                  |
 | shouldHideStatusBar   | `bool`      | false                 | Show or hide the status bar      |
+| <b>Behavior</b>       |             |                       |                                  |
+| isScrollable          | `bool`      | true                  | Force button-only scrolling      |
 
 ## Pull request and feedback are always appreciated

--- a/lib/intro_slider.dart
+++ b/lib/intro_slider.dart
@@ -85,6 +85,10 @@ class IntroSlider extends StatefulWidget {
   /// Show or hide status bar
   final bool shouldHideStatusBar;
 
+  // ---------- Behavior ----------
+  /// Whether or not the slider is scrollable (or controlled only by buttons)
+  final bool isScrollable;
+
   // Constructor
   IntroSlider({
     @required this.slides,
@@ -113,6 +117,7 @@ class IntroSlider extends StatefulWidget {
     this.sizeDot,
     this.locale,
     this.shouldHideStatusBar,
+    this.isScrollable,
   });
 
   @override
@@ -143,6 +148,7 @@ class IntroSlider extends StatefulWidget {
         sizeDot: this.sizeDot,
         locale: this.locale,
         shouldHideStatusBar: this.shouldHideStatusBar,
+        isScrollable: this.isScrollable,
       );
 }
 
@@ -228,6 +234,9 @@ class IntroSliderState extends State<IntroSlider> with SingleTickerProviderState
   /// Show or hide status bar
   bool shouldHideStatusBar;
 
+  /// Allow the slider to scroll
+  bool isScrollable;
+
   // Constructor
   IntroSliderState({
     // List slides
@@ -263,6 +272,9 @@ class IntroSliderState extends State<IntroSlider> with SingleTickerProviderState
     @required this.sizeDot,
     @required this.locale,
     @required this.shouldHideStatusBar,
+    
+    // Behavior
+    @required this.isScrollable,
   });
 
   TabController tabController;
@@ -307,6 +319,10 @@ class IntroSliderState extends State<IntroSlider> with SingleTickerProviderState
       sizeDot = 8.0;
     }
 
+    if (isScrollable == null) {
+      isScrollable = true;
+    }
+
     renderListTabs();
   }
 
@@ -333,6 +349,7 @@ class IntroSliderState extends State<IntroSlider> with SingleTickerProviderState
               TabBarView(
                 children: tabs,
                 controller: tabController,
+                physics: isScrollable ? ScrollPhysics() : NeverScrollableScrollPhysics,
               ),
               renderBottom(),
             ],


### PR DESCRIPTION
Hello,

I wanted to contribute something I've been using for my own project, hopefully other people will find it helpful.  

I'm using flutter-intro-slider for my privacy and license terms, but having users able to just scroll past them doesn't work for that.

This commit (optionally, defaults to normal) stops the scrolling behavior, and by changing the text of the "Next" button to be "Agree",  now it does what I need!

Please let me know if there's anything I've overlooked or any suggested changes.