### PR TITLE
Add prev button

### DIFF
--- a/README.md
+++ b/README.md
@@ -273,6 +273,10 @@ class MySplashScreenState extends State<MySplashScreen> {
 | <b>Next Button (other attributes will have the same Done btn)</b>    |             |                       |                                  |
 | renderNextBtn         | `Widget`    | Button with text NEXT | Render your own NEXT button      |
 | nameNextBtn           | `String`    | "NEXT"                | Change NEXT to any text you want |
+| <b>Prev Button (other attributes will have the same Done btn)</b>    |             |                       |                                  |
+| renderPrevBtn         | `Widget`    | Button with text PREV | Render your own PREV button      |
+| namePrevBtn           | `String`    | "PREV"                | Change PREV to any text you want |
+| isShowPrevBtn         | `bool`      | true                  | Show or hide PREV button         |
 | <b>Done Button</b>    |             |                       |                                  |
 | renderDoneBtn         | `Widget`    | Button with text DONE | Render your own DONE button      |
 | widthDoneBtn          | `double`    | 1/4 screen width      | Width of view wrapper DONE button|

--- a/lib/intro_slider.dart
+++ b/lib/intro_slider.dart
@@ -41,6 +41,16 @@ class IntroSlider extends StatefulWidget {
   /// Change NEXT to any text you want
   final String nameNextBtn;
 
+  // ---------- PREV button ----------
+  /// Render your own PREV button
+  final Widget renderPrevBtn;
+
+  /// Change PREV to any text you want
+  final String namePrevBtn;
+
+  /// Show or hide PREV button (only visible if skip is hidden)
+  final bool isShowPrevBtn;
+
   // ---------- DONE button ----------
   /// Change DONE to any text you want
   final String nameDoneBtn;
@@ -102,15 +112,18 @@ class IntroSlider extends StatefulWidget {
     this.isShowSkipBtn,
     this.borderRadiusSkipBtn,
     this.renderNextBtn,
+    this.renderPrevBtn,
     this.renderDoneBtn,
     this.widthDoneBtn,
     this.onDonePress,
     this.nameNextBtn,
+    this.namePrevBtn,
     this.nameDoneBtn,
     this.styleNameDoneBtn,
     this.colorDoneBtn,
     this.highlightColorDoneBtn,
     this.borderRadiusDoneBtn,
+    this.isShowPrevBtn,
     this.isShowDotIndicator,
     this.colorDot,
     this.colorActiveDot,
@@ -133,14 +146,17 @@ class IntroSlider extends StatefulWidget {
         isShowSkipBtn: this.isShowSkipBtn,
         borderRadiusSkipBtn: this.borderRadiusSkipBtn,
         renderNextBtn: this.renderNextBtn,
+        renderPrevBtn: this.renderPrevBtn,
         renderDoneBtn: this.renderDoneBtn,
         widthDoneBtn: this.widthDoneBtn,
         onDonePress: this.onDonePress,
         nameNextBtn: this.nameNextBtn,
+        namePrevBtn: this.namePrevBtn,
         nameDoneBtn: this.nameDoneBtn,
         styleNameDoneBtn: this.styleNameDoneBtn,
         colorDoneBtn: this.colorDoneBtn,
         highlightColorDoneBtn: this.highlightColorDoneBtn,
+        isShowPrevBtn: this.isShowPrevBtn,
         borderRadiusDoneBtn: this.borderRadiusDoneBtn,
         isShowDotIndicator: this.isShowDotIndicator,
         colorDot: this.colorDot,
@@ -194,9 +210,15 @@ class IntroSliderState extends State<IntroSlider>
   /// Rounded SKIP button
   double borderRadiusSkipBtn;
 
-  // DONE, NEXT button
+  /// Show or hide PREV button
+  bool isShowPrevBtn;
+
+  // DONE, NEXT, PREV button
   /// Render your own NEXT button
   Widget renderNextBtn;
+
+  /// Render your own PREV button
+  Widget renderPrevBtn;
 
   /// Render your own DONE button
   Widget renderDoneBtn;
@@ -209,6 +231,9 @@ class IntroSliderState extends State<IntroSlider>
 
   /// Change NEXT to any text you want
   String nameNextBtn;
+
+    /// Change PREV to any text you want
+  String namePrevBtn;
 
   /// Change DONE to any text you want
   String nameDoneBtn;
@@ -265,14 +290,17 @@ class IntroSliderState extends State<IntroSlider>
 
     // Done button
     @required this.renderNextBtn,
+    @required this.renderPrevBtn,
     @required this.renderDoneBtn,
     @required this.widthDoneBtn,
     @required this.onDonePress,
     @required this.nameNextBtn,
+    @required this.namePrevBtn,
     @required this.nameDoneBtn,
     @required this.styleNameDoneBtn,
     @required this.colorDoneBtn,
     @required this.highlightColorDoneBtn,
+    @required this.isShowPrevBtn,
     @required this.borderRadiusDoneBtn,
 
     // Dot indicator
@@ -393,6 +421,20 @@ class IntroSliderState extends State<IntroSlider>
         style: styleNameDoneBtn,
       );
     }
+
+    // Prev button
+    if (isShowPrevBtn == null || isShowSkipBtn) {
+      isShowPrevBtn = false;
+    }
+    if (namePrevBtn == null) {
+      namePrevBtn = "PREV";
+    }
+    if (renderPrevBtn == null) {
+      renderPrevBtn = Text(
+        namePrevBtn,
+        style: styleNameDoneBtn,
+      );
+    }
   }
 
   @override
@@ -431,14 +473,18 @@ class IntroSliderState extends State<IntroSlider>
   }
 
   Widget buildSkipButton() {
-    return FlatButton(
-      onPressed: onSkipPress,
-      child: renderSkipBtn,
-      color: colorSkipBtn,
-      highlightColor: highlightColorSkipBtn,
-      shape: new RoundedRectangleBorder(
-          borderRadius: new BorderRadius.circular(borderRadiusSkipBtn)),
-    );
+    if (tabController.index + 1 == slides.length) {
+      return Container();
+    } else {
+      return FlatButton(
+        onPressed: onSkipPress,
+        child: renderSkipBtn,
+        color: colorSkipBtn,
+        highlightColor: highlightColorSkipBtn,
+        shape: new RoundedRectangleBorder(
+            borderRadius: new BorderRadius.circular(borderRadiusSkipBtn)),
+      );
+    }
   }
 
   Widget buildDoneButton() {
@@ -450,6 +496,23 @@ class IntroSliderState extends State<IntroSlider>
       shape: new RoundedRectangleBorder(
           borderRadius: new BorderRadius.circular(borderRadiusDoneBtn)),
     );
+  }
+
+  Widget buildPrevButton() {
+    if (tabController.index == 0) {
+      return Container();
+    } else {
+      return FlatButton(
+        onPressed: () {
+          tabController.animateTo(tabController.index - 1);
+        },
+        child: renderPrevBtn,
+        color: colorDoneBtn,
+        highlightColor: highlightColorDoneBtn,
+        shape: new RoundedRectangleBorder(
+            borderRadius: new BorderRadius.circular(borderRadiusDoneBtn)),
+      );
+    }
   }
 
   Widget buildNextButton() {
@@ -472,9 +535,9 @@ class IntroSliderState extends State<IntroSlider>
           // Skip button
           Container(
             alignment: Alignment.center,
-            child: (tabController.index + 1 != slides.length && isShowSkipBtn)
+            child: (isShowSkipBtn)
                 ? buildSkipButton()
-                : Container(),
+                : (isShowPrevBtn ? buildPrevButton() : Container()),
             width: widthSkipBtn ?? MediaQuery.of(context).size.width / 4,
           ),
 

--- a/lib/intro_slider.dart
+++ b/lib/intro_slider.dart
@@ -364,6 +364,70 @@ class IntroSliderState extends State<IntroSlider>
     );
   }
 
+  Widget _buildSkipButton() {
+    Widget buttonChild = renderSkipBtn;
+    if (buttonChild == null) {
+      buttonChild = Text(
+        nameSkipBtn ?? "SKIP",
+        style: styleNameSkipBtn ?? TextStyle(color: Colors.white),
+      );
+    }
+
+    return FlatButton(
+      child: buttonChild,
+      onPressed: onSkipPress,
+      color: colorSkipBtn != null ? colorSkipBtn : Colors.transparent,
+      highlightColor: highlightColorSkipBtn != null
+          ? highlightColorSkipBtn
+          : Colors.white.withOpacity(0.3),
+      shape: new RoundedRectangleBorder(
+          borderRadius: new BorderRadius.circular(borderRadiusSkipBtn ?? 30.0)),
+    );
+  }
+
+  Widget _buildDoneButton() {
+    Widget buttonChild = renderDoneBtn;
+    if (buttonChild == null) {
+      buttonChild = Text(
+        nameDoneBtn ?? "DONE",
+        style: styleNameDoneBtn ?? TextStyle(color: Colors.white),
+      );
+    }
+    return FlatButton(
+      child: buttonChild,
+      onPressed: onDonePress,
+      color: colorDoneBtn != null ? colorDoneBtn : Colors.transparent,
+      highlightColor: highlightColorDoneBtn != null
+          ? highlightColorDoneBtn
+          : Colors.white.withOpacity(0.3),
+      shape: new RoundedRectangleBorder(
+          borderRadius: new BorderRadius.circular(borderRadiusDoneBtn ?? 30.0)),
+    );
+  }
+
+  Widget _buildNextButton() {
+    Widget buttonChild = renderNextBtn;
+    if (buttonChild == null) {
+      buttonChild = Text(
+        nameNextBtn ?? "NEXT",
+        style: styleNameDoneBtn ?? TextStyle(color: Colors.white),
+      );
+    }
+
+    return FlatButton(
+      onPressed: () {
+        tabController.animateTo(tabController.index + 1);
+      },
+      child: buttonChild,
+      color: colorDoneBtn != null ? colorDoneBtn : Colors.transparent,
+      highlightColor: highlightColorDoneBtn != null
+          ? highlightColorDoneBtn
+          : Colors.white.withOpacity(0.3),
+      shape: new RoundedRectangleBorder(
+          borderRadius: new BorderRadius.circular(borderRadiusDoneBtn ?? 30.0)),
+    );
+  }
+
   Widget renderBottom() {
     return Positioned(
       child: Row(
@@ -372,37 +436,7 @@ class IntroSliderState extends State<IntroSlider>
           Container(
             alignment: Alignment.center,
             child: (tabController.index + 1 != slides.length && isShowSkipBtn)
-                ? renderSkipBtn != null
-                    ? FlatButton(
-                        child: renderSkipBtn,
-                        onPressed: onSkipPress,
-                        color: colorSkipBtn != null
-                            ? colorSkipBtn
-                            : Colors.transparent,
-                        highlightColor: highlightColorSkipBtn != null
-                            ? highlightColorSkipBtn
-                            : Colors.white.withOpacity(0.3),
-                        shape: new RoundedRectangleBorder(
-                            borderRadius: new BorderRadius.circular(
-                                borderRadiusSkipBtn ?? 30.0)),
-                      )
-                    : FlatButton(
-                        onPressed: onSkipPress,
-                        child: Text(
-                          nameSkipBtn ?? "SKIP",
-                          style: styleNameSkipBtn ??
-                              TextStyle(color: Colors.white),
-                        ),
-                        color: colorSkipBtn != null
-                            ? colorSkipBtn
-                            : Colors.transparent,
-                        highlightColor: highlightColorSkipBtn != null
-                            ? highlightColorSkipBtn
-                            : Colors.white.withOpacity(0.3),
-                        shape: new RoundedRectangleBorder(
-                            borderRadius: new BorderRadius.circular(
-                                borderRadiusSkipBtn ?? 30.0)),
-                      )
+                ? _buildSkipButton()
                 : Container(),
             width: widthSkipBtn ?? MediaQuery.of(context).size.width / 4,
           ),
@@ -421,72 +455,8 @@ class IntroSliderState extends State<IntroSlider>
           Container(
             alignment: Alignment.center,
             child: tabController.index + 1 == slides.length
-                ? (renderDoneBtn != null
-                    ? FlatButton(
-                        child: renderDoneBtn,
-                        onPressed: onDonePress,
-                        color: colorDoneBtn != null
-                            ? colorDoneBtn
-                            : Colors.transparent,
-                        highlightColor: highlightColorDoneBtn != null
-                            ? highlightColorDoneBtn
-                            : Colors.white.withOpacity(0.3),
-                        shape: new RoundedRectangleBorder(
-                            borderRadius: new BorderRadius.circular(
-                                borderRadiusDoneBtn ?? 30.0)),
-                      )
-                    : FlatButton(
-                        onPressed: onDonePress,
-                        child: Text(
-                          nameDoneBtn ?? "DONE",
-                          style: styleNameDoneBtn ??
-                              TextStyle(color: Colors.white),
-                        ),
-                        color: colorDoneBtn != null
-                            ? colorDoneBtn
-                            : Colors.transparent,
-                        highlightColor: highlightColorDoneBtn != null
-                            ? highlightColorDoneBtn
-                            : Colors.white.withOpacity(0.3),
-                        shape: new RoundedRectangleBorder(
-                            borderRadius: new BorderRadius.circular(
-                                borderRadiusDoneBtn ?? 30.0)),
-                      ))
-                : (renderNextBtn != null
-                    ? FlatButton(
-                        onPressed: () {
-                          tabController.animateTo(tabController.index + 1);
-                        },
-                        child: renderNextBtn,
-                        color: colorDoneBtn != null
-                            ? colorDoneBtn
-                            : Colors.transparent,
-                        highlightColor: highlightColorDoneBtn != null
-                            ? highlightColorDoneBtn
-                            : Colors.white.withOpacity(0.3),
-                        shape: new RoundedRectangleBorder(
-                            borderRadius: new BorderRadius.circular(
-                                borderRadiusDoneBtn ?? 30.0)),
-                      )
-                    : FlatButton(
-                        onPressed: () {
-                          tabController.animateTo(tabController.index + 1);
-                        },
-                        child: Text(
-                          nameNextBtn ?? "NEXT",
-                          style: styleNameDoneBtn ??
-                              TextStyle(color: Colors.white),
-                        ),
-                        color: colorDoneBtn != null
-                            ? colorDoneBtn
-                            : Colors.transparent,
-                        highlightColor: highlightColorDoneBtn != null
-                            ? highlightColorDoneBtn
-                            : Colors.white.withOpacity(0.3),
-                        shape: new RoundedRectangleBorder(
-                            borderRadius: new BorderRadius.circular(
-                                borderRadiusDoneBtn ?? 30.0)),
-                      )),
+                ? _buildDoneButton()
+                : _buildNextButton(),
             width: widthDoneBtn ?? MediaQuery.of(context).size.width / 4,
           ),
         ],

--- a/lib/intro_slider.dart
+++ b/lib/intro_slider.dart
@@ -154,6 +154,15 @@ class IntroSlider extends StatefulWidget {
 
 class IntroSliderState extends State<IntroSlider>
     with SingleTickerProviderStateMixin {
+  /// Default values
+  static TextStyle defaultBtnNameTextStyle = TextStyle(color: Colors.white);
+
+  static double defaultBtnBorderRadius = 30.0;
+
+  static Color defaultBtnColor = Colors.transparent;
+
+  static Color defaultBtnHighlightColor = Colors.white.withOpacity(0.3);
+
   /// An array of Slide object
   final List<Slide> slides;
 
@@ -293,20 +302,7 @@ class IntroSliderState extends State<IntroSlider>
       this.setState(() {});
     });
 
-    // Skip button
-    if (onSkipPress == null) {
-      onSkipPress = () {
-        tabController.animateTo(slides.length - 1);
-      };
-    }
-    if (isShowSkipBtn == null) {
-      isShowSkipBtn = true;
-    }
-
-    // Done button
-    if (onDonePress == null) {
-      onDonePress = () {};
-    }
+    setupButtonDefaultValues();
 
     // Dot indicator
     if (isShowDotIndicator == null) {
@@ -327,6 +323,76 @@ class IntroSliderState extends State<IntroSlider>
     }
 
     renderListTabs();
+  }
+
+  void setupButtonDefaultValues() {
+    // Skip button
+    if (onSkipPress == null) {
+      onSkipPress = () {
+        tabController.animateTo(slides.length - 1);
+      };
+    }
+    if (isShowSkipBtn == null) {
+      isShowSkipBtn = true;
+    }
+    if (styleNameSkipBtn == null) {
+      styleNameSkipBtn = defaultBtnNameTextStyle;
+    }
+    if (nameSkipBtn == null) {
+      nameSkipBtn = "SKIP";
+    }
+    if (renderSkipBtn == null) {
+      renderSkipBtn = Text(
+        nameSkipBtn,
+        style: styleNameSkipBtn,
+      );
+    }
+    if (colorSkipBtn == null) {
+      colorSkipBtn = defaultBtnColor;
+    }
+    if (highlightColorSkipBtn == null) {
+      highlightColorSkipBtn = defaultBtnHighlightColor;
+    }
+    if (borderRadiusSkipBtn == null) {
+      borderRadiusSkipBtn = defaultBtnBorderRadius;
+    }
+
+    // Done button
+    if (onDonePress == null) {
+      onDonePress = () {};
+    }
+    if (styleNameDoneBtn == null) {
+      styleNameDoneBtn = defaultBtnNameTextStyle;
+    }
+    if (nameDoneBtn == null) {
+      nameDoneBtn = "DONE";
+    }
+    if (renderDoneBtn == null) {
+      renderDoneBtn = Text(
+        nameDoneBtn,
+        style: styleNameDoneBtn,
+      );
+    }
+    if (colorDoneBtn == null) {
+      colorDoneBtn = defaultBtnColor;
+    }
+    if (highlightColorDoneBtn == null) {
+      highlightColorDoneBtn = defaultBtnHighlightColor;
+    }
+    if (borderRadiusDoneBtn == null) {
+      borderRadiusDoneBtn = defaultBtnBorderRadius;
+    }
+
+    // Next button
+    if (nameNextBtn == null) {
+      nameNextBtn = "NEXT";
+    }
+    if (renderNextBtn == null) {
+      renderNextBtn = Text(
+        nameNextBtn,
+        style: styleNameDoneBtn,
+      );
+    }
   }
 
   @override
@@ -364,67 +430,38 @@ class IntroSliderState extends State<IntroSlider>
     );
   }
 
-  Widget _buildSkipButton() {
-    Widget buttonChild = renderSkipBtn;
-    if (buttonChild == null) {
-      buttonChild = Text(
-        nameSkipBtn ?? "SKIP",
-        style: styleNameSkipBtn ?? TextStyle(color: Colors.white),
-      );
-    }
-
+  Widget buildSkipButton() {
     return FlatButton(
-      child: buttonChild,
       onPressed: onSkipPress,
-      color: colorSkipBtn != null ? colorSkipBtn : Colors.transparent,
-      highlightColor: highlightColorSkipBtn != null
-          ? highlightColorSkipBtn
-          : Colors.white.withOpacity(0.3),
+      child: renderSkipBtn,
+      color: colorSkipBtn,
+      highlightColor: highlightColorSkipBtn,
       shape: new RoundedRectangleBorder(
-          borderRadius: new BorderRadius.circular(borderRadiusSkipBtn ?? 30.0)),
+          borderRadius: new BorderRadius.circular(borderRadiusSkipBtn)),
     );
   }
 
-  Widget _buildDoneButton() {
-    Widget buttonChild = renderDoneBtn;
-    if (buttonChild == null) {
-      buttonChild = Text(
-        nameDoneBtn ?? "DONE",
-        style: styleNameDoneBtn ?? TextStyle(color: Colors.white),
-      );
-    }
+  Widget buildDoneButton() {
     return FlatButton(
-      child: buttonChild,
       onPressed: onDonePress,
-      color: colorDoneBtn != null ? colorDoneBtn : Colors.transparent,
-      highlightColor: highlightColorDoneBtn != null
-          ? highlightColorDoneBtn
-          : Colors.white.withOpacity(0.3),
+      child: renderDoneBtn,
+      color: colorDoneBtn,
+      highlightColor: highlightColorDoneBtn,
       shape: new RoundedRectangleBorder(
-          borderRadius: new BorderRadius.circular(borderRadiusDoneBtn ?? 30.0)),
+          borderRadius: new BorderRadius.circular(borderRadiusDoneBtn)),
     );
   }
 
-  Widget _buildNextButton() {
-    Widget buttonChild = renderNextBtn;
-    if (buttonChild == null) {
-      buttonChild = Text(
-        nameNextBtn ?? "NEXT",
-        style: styleNameDoneBtn ?? TextStyle(color: Colors.white),
-      );
-    }
-
+  Widget buildNextButton() {
     return FlatButton(
       onPressed: () {
         tabController.animateTo(tabController.index + 1);
       },
-      child: buttonChild,
-      color: colorDoneBtn != null ? colorDoneBtn : Colors.transparent,
-      highlightColor: highlightColorDoneBtn != null
-          ? highlightColorDoneBtn
-          : Colors.white.withOpacity(0.3),
+      child: renderNextBtn,
+      color: colorDoneBtn,
+      highlightColor: highlightColorDoneBtn,
       shape: new RoundedRectangleBorder(
-          borderRadius: new BorderRadius.circular(borderRadiusDoneBtn ?? 30.0)),
+          borderRadius: new BorderRadius.circular(borderRadiusDoneBtn)),
     );
   }
 
@@ -436,7 +473,7 @@ class IntroSliderState extends State<IntroSlider>
           Container(
             alignment: Alignment.center,
             child: (tabController.index + 1 != slides.length && isShowSkipBtn)
-                ? _buildSkipButton()
+                ? buildSkipButton()
                 : Container(),
             width: widthSkipBtn ?? MediaQuery.of(context).size.width / 4,
           ),
@@ -455,8 +492,8 @@ class IntroSliderState extends State<IntroSlider>
           Container(
             alignment: Alignment.center,
             child: tabController.index + 1 == slides.length
-                ? _buildDoneButton()
-                : _buildNextButton(),
+                ? buildDoneButton()
+                : buildNextButton(),
             width: widthDoneBtn ?? MediaQuery.of(context).size.width / 4,
           ),
         ],


### PR DESCRIPTION
This commit adds support for prev button.
It'll be setup exactly as NEXT button.
If skip button is enabled, it won't be visible, also it won't be visible on first page (since there is no prev for first).
It requires changes from https://github.com/duytq94/flutter-intro-slider/pull/16