### PR TITLE
[FIX] Fix trouble with double call on callback onTabChangeCompleted

### DIFF
--- a/lib/intro_slider.dart
+++ b/lib/intro_slider.dart
@@ -480,7 +480,7 @@ class IntroSliderState extends State<IntroSlider>
         currentTabIndex = tabController.index;
       }
       currentAnimationValue = tabController.animation.value;
-      if (this.onTabChangeCompleted != null) {
+      if (tabController.indexIsChanging && this.onTabChangeCompleted != null) {
         this.onTabChangeCompleted(tabController.index);
       }
     });


### PR DESCRIPTION
Before call onTabChangeCompleted check if the indexIsChanging

```dart
...
onTabChangeCompleted: (step) {
    print(step)
}
...
```

Before apply the patch the output is

```log
I/flutter (19184): 1
I/flutter (19184): 1
```

After apply the patch the output is

```log
I/flutter (19184): 1
```
