### PR TITLE
Added scrollbar for tab content

### DIFF
--- a/lib/intro_slider.dart
+++ b/lib/intro_slider.dart
@@ -137,6 +137,9 @@ class IntroSlider extends StatefulWidget {
   /// Show or hide status bar
   final bool shouldHideStatusBar;
 
+  /// Always show the verticle scrollbar on content that needs to scroll
+  final bool alwaysShowScrollbarForContent;
+
   // Constructor
   IntroSlider({
     // Slides
@@ -195,6 +198,7 @@ class IntroSlider extends StatefulWidget {
     // Behavior
     this.isScrollable,
     this.shouldHideStatusBar,
+    this.alwaysShowScrollbarForContent = false,
   });
 
   @override
@@ -256,6 +260,7 @@ class IntroSlider extends StatefulWidget {
       // Behavior
       isScrollable: this.isScrollable,
       shouldHideStatusBar: this.shouldHideStatusBar,
+      alwaysShowScrollbarForContent: this.alwaysShowScrollbarForContent,
     );
   }
 }
@@ -402,6 +407,9 @@ class IntroSliderState extends State<IntroSlider>
   /// Show or hide status bar
   bool shouldHideStatusBar;
 
+  /// Always show the verticle scrollbar on content that needs to scroll
+  bool alwaysShowScrollbarForContent;
+
   // Constructor
   IntroSliderState({
     // List slides
@@ -460,6 +468,7 @@ class IntroSliderState extends State<IntroSlider>
     // Behavior
     @required this.isScrollable,
     @required this.shouldHideStatusBar,
+    @required this.alwaysShowScrollbarForContent,
   });
 
   TabController tabController;
@@ -969,6 +978,7 @@ class IntroSliderState extends State<IntroSlider>
     Color backgroundOpacityColor,
     BlendMode backgroundBlendMode,
   ) {
+    final _scrollController = ScrollController();
     return Container(
       width: double.infinity,
       height: double.infinity,
@@ -1000,58 +1010,63 @@ class IntroSliderState extends State<IntroSlider>
             ),
       child: Container(
         margin: EdgeInsets.only(bottom: 60.0),
-        child: ListView(
-          children: <Widget>[
-            Container(
-              // Title
-              child: widgetTitle ??
-                  Text(
-                    title ?? "",
-                    style: styleTitle ??
-                        TextStyle(
-                          color: Colors.white,
-                          fontWeight: FontWeight.bold,
-                          fontSize: 30.0,
-                        ),
-                    maxLines: maxLineTitle != null ? maxLineTitle : 1,
-                    textAlign: TextAlign.center,
-                    overflow: TextOverflow.ellipsis,
-                  ),
-              margin: marginTitle ??
-                  EdgeInsets.only(
-                      top: 70.0, bottom: 50.0, left: 20.0, right: 20.0),
-            ),
+        child: Scrollbar(
+          isAlwaysShown: alwaysShowScrollbarForContent,
+          controller: _scrollController,
+          child: ListView(
+            controller: _scrollController,
+            children: <Widget>[
+              Container(
+                // Title
+                child: widgetTitle ??
+                    Text(
+                      title ?? "",
+                      style: styleTitle ??
+                          TextStyle(
+                            color: Colors.white,
+                            fontWeight: FontWeight.bold,
+                            fontSize: 30.0,
+                          ),
+                      maxLines: maxLineTitle != null ? maxLineTitle : 1,
+                      textAlign: TextAlign.center,
+                      overflow: TextOverflow.ellipsis,
+                    ),
+                margin: marginTitle ??
+                    EdgeInsets.only(
+                        top: 70.0, bottom: 50.0, left: 20.0, right: 20.0),
+              ),
 
-            // Image or Center widget
-            GestureDetector(
-              child: pathImage != null
-                  ? Image.asset(
-                      pathImage,
-                      width: widthImage ?? 200.0,
-                      height: heightImage ?? 200.0,
-                      fit: foregroundImageFit ?? BoxFit.contain,
-                    )
-                  : Center(child: centerWidget ?? Container()),
-              onTap: onCenterItemPress,
-            ),
+              // Image or Center widget
+              GestureDetector(
+                child: pathImage != null
+                    ? Image.asset(
+                        pathImage,
+                        width: widthImage ?? 200.0,
+                        height: heightImage ?? 200.0,
+                        fit: foregroundImageFit ?? BoxFit.contain,
+                      )
+                    : Center(child: centerWidget ?? Container()),
+                onTap: onCenterItemPress,
+              ),
 
-            // Description
-            Container(
-              child: widgetDescription ??
-                  Text(
-                    description ?? "",
-                    style: styleDescription ??
-                        TextStyle(color: Colors.white, fontSize: 18.0),
-                    textAlign: TextAlign.center,
-                    maxLines: maxLineTextDescription != null
-                        ? maxLineTextDescription
-                        : 100,
-                    overflow: TextOverflow.ellipsis,
-                  ),
-              margin: marginDescription ??
-                  EdgeInsets.fromLTRB(20.0, 50.0, 20.0, 50.0),
-            ),
-          ],
+              // Description
+              Container(
+                child: widgetDescription ??
+                    Text(
+                      description ?? "",
+                      style: styleDescription ??
+                          TextStyle(color: Colors.white, fontSize: 18.0),
+                      textAlign: TextAlign.center,
+                      maxLines: maxLineTextDescription != null
+                          ? maxLineTextDescription
+                          : 100,
+                      overflow: TextOverflow.ellipsis,
+                    ),
+                margin: marginDescription ??
+                    EdgeInsets.fromLTRB(20.0, 50.0, 20.0, 50.0),
+              ),
+            ],
+          ),
         ),
       ),
     );


### PR DESCRIPTION
Added a scrollbar to tab content so you can tell if there is more to see before continuing (useful when the content is shown on smaller screens or with larger text and it's not always obvious there is more to read). Added the ability to always show the scrollbar or to only show when interacted with. If you can't scroll then no scrollbar is shown.